### PR TITLE
remove Cypress record key

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ githubToken:
 providerToken:
   description: "Meshery Authentication Provider Token"
   required: true
-cypressRecordKey:
-  description: "cypress record key"
-  required: false
 prNumber:
   description: "The Pull request on which comment has to be made"
   required: false


### PR DESCRIPTION
If this is still optionally supported, then we can leave it as-is. 