### PR TITLE
Fix: snapshotting service of MeshMap canvas

### DIFF
--- a/cypress-action/cypress/e2e/e2e/loadDesign.js
+++ b/cypress-action/cypress/e2e/e2e/loadDesign.js
@@ -3,14 +3,18 @@
 /// <reference types="../../support" /> 
 
 import { TIME } from "../../support/constants";
-import { beforeEachCallbackForCustomUrl } from "../../support/helpers";
+import { beforeEachCallbackForCustomUrl, saveGraph } from "../../support/helpers";
 
 describe("Infra Shot Automated Runner", () => {
-  beforeEach(()=> beforeEachCallbackForCustomUrl(`/extension/meshmap?application=${Cypress.env("applicationId").replace(/['"]+/g, '')}`))
+  beforeEach(() => beforeEachCallbackForCustomUrl(`/extension/meshmap?application=${Cypress.env("applicationId").replace(/['"]+/g, '')}`))
 
   it("load a design/application with ID", () => {
-    cy.wait(TIME.X4LARGE)
-    cy.get("#download").click({force: true});
+    cy.wait(TIME.X4LARGE);
+    cy.window().then(window => {
+      cy.wait(TIME.SMALL);
+      const cyto = window.cyto;
+      saveGraph(cyto);
+    })
   })
 })
 

--- a/cypress-action/cypress/support/helpers.js
+++ b/cypress-action/cypress/support/helpers.js
@@ -30,3 +30,38 @@ export const beforeEachCallbackForCustomUrl = (customPath) => {
   cy.visit(customPath);
   cy.wait(waitFor(extension.alias), { timeout: 60_000 });
 }
+
+export const saveGraph = (cy) => {
+  let image = cy.png();
+  let lnk = document.createElement("a"),
+    date = new Date(),
+    e;
+  lnk.href = image;
+  lnk.download =
+    "MeshMap-" + date.toDateString() + "/" + date.toLocaleTimeString() + ".png";
+
+  if (document.createEvent) {
+    e = document.createEvent("MouseEvents");
+    e.initMouseEvent(
+      "click",
+      true,
+      true,
+      window,
+      0,
+      0,
+      0,
+      0,
+      0,
+      false,
+      false,
+      false,
+      false,
+      0,
+      null
+    );
+
+    lnk.dispatchEvent(e);
+  } else if (lnk.fireEvent) {
+    lnk.fireEvent("onclick");
+  }
+};


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

With MeshMap enhancement around the canvas control buttons, the screenshot service is failing.
Now, the click is done programatically, given anymore changes in the MeshMap, the snapshot service wont fail.



- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshmap! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->