### PR TITLE
[chore] Fixes invalid semantic error

### DIFF
--- a/workflow-templates/file-uploadTemplate.yaml
+++ b/workflow-templates/file-uploadTemplate.yaml
@@ -43,4 +43,4 @@ jobs:
           providerToken: ${{ secrets.PROVIDER_TOKEN }} # Meshery Cloud Authentication token, signin to meshery-cloud to get one, example: ey.....
           prNumber: ${{ env.PULL_NO }} # auto-filled from the above step
           application_type: $ph_application_type # your application type, could be any of three: "Kubernetes Manifest", "Docker Compose", "Helm Chart"
-          filePath: ${{ inputs.fileName == '' && $ph_filePath || inputs.fileName }} # relative file-path from the root directory in the github-runner env, you might require to checkout the repository as described in step 2
+          filePath: ${{ inputs.fileName == '' && '$ph_filePath' || inputs.fileName }} # relative file-path from the root directory in the github-runner env, you might require to checkout the repository as described in step 2

--- a/workflow-templates/url-uploadTemplate.yaml
+++ b/workflow-templates/url-uploadTemplate.yaml
@@ -34,6 +34,6 @@ jobs:
           providerToken: ${{ secrets.PROVIDER_TOKEN }} # Meshery Cloud Authentication token, signin to meshery-cloud to get one, example: ey.....
           prNumber: ${{ env.PULL_NO }} # auto-filled from the above step
           application_type: $ph_application_type # your application type, could be any of three: "Kubernetes Manifest", "Docker Compose", "Helm Chart"
-          application_url: ${{ inputs.fileURL == '' && $ph_application_url || inputs.fileURL }}
+          application_url: ${{ inputs.fileURL == '' && '$ph_application_url' || inputs.fileURL }}
           
         


### PR DESCRIPTION
**Notes for Reviewers**

Currently, when a new meshmap snapshot workflow is added, then it replaces `ph_filePath` with `<file-path>`.
Now the issue is that `${{ inputs.fileName == '' && $ph_filePath || inputs.fileName }}` resolves to `${{ inputs.fileName == '' && <file-path> || inputs.fileName }}` which is semantically incorrect as `<file-path>` is treated as variable instead of a string.

So, this PR updates the template workflow file to ensure on replacement the line resolves to `${{ inputs.fileName == '' && '<file-path>' || inputs.fileName }}`.

This would also fix: https://github.com/meshery/meshery/actions/runs/7268615022

This PR fixes #



- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshmap! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->