### PR TITLE
[chore] Bump screenshot version in templates

### DIFF
--- a/workflow-templates/file-uploadTemplate.yaml
+++ b/workflow-templates/file-uploadTemplate.yaml
@@ -37,7 +37,7 @@ jobs:
           path: action
           repository: layer5labs/meshmap-snapshot
       - id: test_result
-        uses: layer5labs/MeshMap-Snapshot@v0.0.8
+        uses: layer5labs/MeshMap-Snapshot@v0.1.4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }} # github's personal access token example: "ghp_...."
           providerToken: ${{ secrets.PROVIDER_TOKEN }} # Meshery Cloud Authentication token, signin to meshery-cloud to get one, example: ey.....

--- a/workflow-templates/url-uploadTemplate.yaml
+++ b/workflow-templates/url-uploadTemplate.yaml
@@ -28,7 +28,7 @@ jobs:
           path: action
           repository: layer5labs/meshmap-snapshot
       - id: test_result
-        uses: layer5labs/MeshMap-Snapshot@v0.0.8
+        uses: layer5labs/MeshMap-Snapshot@v0.1.4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }} # github's personal access token example: "ghp_...."
           providerToken: ${{ secrets.PROVIDER_TOKEN }} # Meshery Cloud Authentication token, signin to meshery-cloud to get one, example: ey.....


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the latest version into screenshot service templates.

**This is just a bandage. Real fix would be either updating this through a workflow when a new release is out or updating this at runtime inside Layer5 Cloud when users are connecting to GitHub.
I believe later would be best. I'll look into this.**

_At least new users would not install an older version until we make next release._

This PR fixes #



- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshmap! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->