### PR TITLE
Fix failing pattern upload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -157,5 +157,5 @@ runs:
         repository: ${{github.repository}}
         number: ${{ inputs.prNumber }}
         id: meshmap-snapshot
-        message: '[<img src="${{env.RESOURCE_URL}}">](https://meshery.layer5.io/catalog/content/applications)'
+        message: '[<img src="${{env.RESOURCE_URL}}">](https://meshery.layer5.io/catalog/${{ env.APPLICATION_ID }})'
         append: false


### PR DESCRIPTION
**Notes for Reviewers**

The datatype for PatternFile in MesheryServer was changed from `string` to `bytes` recently, but the snapshot service wasn't updated, causing it to fail, this PR updates the service to ensure the payload is in the correct format.


- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshmap! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->