### PR TITLE
[fix] donot exit the snapshot on app exceptions

### DIFF
--- a/cypress-action/cypress/support/e2e.js
+++ b/cypress-action/cypress/support/e2e.js
@@ -14,7 +14,8 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands";
+import "./events";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress-action/cypress/support/events.js
+++ b/cypress-action/cypress/support/events.js
@@ -1,0 +1,6 @@
+Cypress.on("uncaught:exception", (err, runnable) => {
+  console.error("Uncaught Application Error :", err, runnable);
+  // returning false here prevents Cypress from
+  // failing the test
+  return false;
+});


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #
the pr prevents the whole snapshot from getting crashed on some uncaught internal exception ( like arising from failed api request using the old axios , in some promise ) 


also logs back the whole exception which might help in debugging them


- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshmap! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->